### PR TITLE
Prerequisites-Linux

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -31,3 +31,6 @@ All notable changes to `Black Dashboard` frontend preset for Laravel will be doc
 
   - Update to Laravel 9.x
 
+## Version 1.1.0 - 2024-05-27
+
+- Update to Laravel 11.x


### PR DESCRIPTION
I think the link for linux in Prerequisites is outdated. [https://howtoubuntu.org/how-to-install-lamp-on-ubuntu](https://howtoubuntu.org/how-to-install-lamp-on-ubuntu) If appropriate, that Link can be changed with this link. [https://howtoubuntu.org/how-to/install-update-upgrade-to-the-latest-version-of/lamp-in-ubuntu/](https://howtoubuntu.org/how-to/install-update-upgrade-to-the-latest-version-of/lamp-in-ubuntu/)
